### PR TITLE
remove no-std due to a roadmap change to also include network components

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,1 @@
-#![no_std]
-
 pub mod traits;

--- a/src/traits/error.rs
+++ b/src/traits/error.rs
@@ -1,7 +1,7 @@
-pub trait Error<'a> {
-    fn source(&self) -> &'a str;
+pub trait Error {
+    fn source(&self) -> String;
     fn code(&self) -> u64;
-    fn module(&self) -> &'a str;
+    fn module(&self) -> String;
 
-    fn new(source: &'a str, code: u64, module: &'a str) -> Self;
+    fn new(source: String, code: u64, module: String) -> Self;
 }

--- a/src/traits/network.rs
+++ b/src/traits/network.rs
@@ -1,11 +1,11 @@
-pub trait Node<'a> {
-    type Error: crate::traits::error::Error<'a>;
+pub trait Node {
+    type Error: crate::traits::error::Error;
 
     fn id(&self) -> u64;
     fn query(&mut self) -> Result<(), Self::Error>;
 }
 
-pub trait Network<'a> {
-    type Node: Node<'a>;
-    fn nodes(&self) -> &[Self::Node];
+pub trait Network {
+    type Node: Node;
+    fn nodes(&self) -> Vec<Self::Node>;
 }

--- a/src/traits/query.rs
+++ b/src/traits/query.rs
@@ -1,12 +1,12 @@
-pub trait Query<'a> {
-    type Context: QueryContext<'a>;
+pub trait Query {
+    type Context: QueryContext;
     fn context(&self) -> &Self::Context;
 }
 
-pub trait QueryContext<'a> {
-    type Error: crate::traits::error::Error<'a>;
+pub trait QueryContext {
+    type Error: crate::traits::error::Error;
 
-    fn get(&self, key: &'a str) -> &'a str;
-    fn set(&mut self, key: &'a str, value: &'a str) -> Result<(), Self::Error>;
+    fn get(&self, key: String) -> String;
+    fn set(&mut self, key: String, value: String) -> Result<(), Self::Error>;
     fn clear(&mut self);
 }

--- a/src/traits/sampler.rs
+++ b/src/traits/sampler.rs
@@ -1,9 +1,9 @@
-pub trait Sampler<'a> {
+pub trait Sampler {
     type SamplingType;
-    type Error: crate::traits::error::Error<'a>;
+    type Error: crate::traits::error::Error;
 
     fn sample(
-        items: &[Self::SamplingType],
+        items: Vec<Self::SamplingType>,
         sample_size: u64,
-    ) -> Result<&[Self::SamplingType], Self::Error>;
+    ) -> Result<Vec<Self::SamplingType>, Self::Error>;
 }


### PR DESCRIPTION
- Removing `no-std` and convert `&'a str` to String